### PR TITLE
Extract Stories footer links into method

### DIFF
--- a/src/Stories/Stories.php
+++ b/src/Stories/Stories.php
@@ -304,6 +304,43 @@ class Stories {
 	}
 
 	/**
+	 * Footer links shown below the stories list.
+	 *
+	 * The labels live here rather than in views/utility-story-template.php because that view
+	 * is listed in every consuming plugin's php-scoper `exclude-files`: it opens with inline
+	 * HTML, so scoping it would inject the `namespace ...;` statement into the first PHP block
+	 * it finds - mid-file - which is a fatal parse error. Excluded files skip the `patchers`
+	 * pass as well, so the text-domain placeholder was never rewritten there while every
+	 * other string in the package was. This file is scoped normally, so the placeholder below
+	 * is replaced with the plugin's own text domain like the rest of them.
+	 *
+	 * @return array List of links, each with `url`, `label` and `style` keys.
+	 */
+	public function get_footer_links() {
+
+		return apply_filters(
+			'wpmet/stories/footer_links',
+			array(
+				array(
+					'url'   => 'https://wpmet.com/support-ticket',
+					'label' => __( 'Need Help?', 'text-domain' ),
+					'style' => '',
+				),
+				array(
+					'url'   => 'https://wpmet.com/blog/',
+					'label' => __( 'Blog', 'text-domain' ),
+					'style' => '',
+				),
+				array(
+					'url'   => 'https://wpmet.com/fb-group',
+					'label' => __( 'Facebook Community', 'text-domain' ),
+					'style' => 'color: #27ae60;',
+				),
+			)
+		);
+	}
+
+	/**
 	 * Crosscheck if Story library will be shown at current WP admin page or not
 	 *
 	 * @param string $b_screen

--- a/src/Stories/views/utility-story-template.php
+++ b/src/Stories/views/utility-story-template.php
@@ -134,17 +134,11 @@ endforeach;
 
 <div class="utility-dashboard-widget-block">
 	<div class="utility-footer-bar">
-		<a href="https://wpmet.com/support-ticket" target="_blank" rel="noopener noreferrer">
-			<?php echo esc_html__( 'Need Help?', 'text-domain' ); ?>
-			<span aria-hidden="true" class="dashicons dashicons-external"></span>
-		</a>
-		<a href="https://wpmet.com/blog/" target="_blank" rel="noopener noreferrer">
-		<?php echo esc_html__( 'Blog', 'text-domain' ); ?>
-			<span aria-hidden="true" class="dashicons dashicons-external"></span>
-		</a>
-		<a href="https://wpmet.com/fb-group" target="_blank" rel="noopener noreferrer" style="color: #27ae60;">
-			<?php echo esc_html__( 'Facebook Community', 'text-domain' ); ?>
-			<span aria-hidden="true" class="dashicons dashicons-external"></span>
-		</a>
+		<?php foreach ( $this->get_footer_links() as $footer_link ) : ?>
+			<a href="<?php echo esc_url( $footer_link['url'] ); ?>" target="_blank" rel="noopener noreferrer"<?php echo ( isset( $footer_link['style'] ) && $footer_link['style'] !== '' ) ? ' style="' . esc_attr( $footer_link['style'] ) . '"' : ''; ?>>
+				<?php echo esc_html( $footer_link['label'] ); ?>
+				<span aria-hidden="true" class="dashicons dashicons-external"></span>
+			</a>
+		<?php endforeach; ?>
 	</div>
 </div>


### PR DESCRIPTION
Add Stories::get_footer_links() returning an array of footer links (url, label, style) and expose them via the 'wpmet/stories/footer_links' filter. Rationale: move translatable labels out of the excluded view file so php-scoper / text-domain placeholder replacement works normally. Update utility-story-template.php to iterate the links, escape URL/label/style, and render the same anchor + dashicon markup. Keeps behavior identical while enabling consumers to customize links via the filter.